### PR TITLE
Fix web audio connecting to parameter

### DIFF
--- a/src/elm-web-audio.js
+++ b/src/elm-web-audio.js
@@ -290,7 +290,7 @@ export class VirtualAudioContext extends AudioContext {
 
         window.setTimeout(() => {
             if (from in this.nodes && toNode in this.nodes) {
-                if (toParam && toParam in this.nodes) {
+                if (toParam && toParam in this.nodes[toNode]) {
                     this.nodes[from].connect(this.nodes[toNode][toParam])
                 } else {
                     this.nodes[from].connect(this.nodes[toNode], 0, 0)


### PR DESCRIPTION
At elm-web-audio.js:293 the if should check whether the target parameter exists on the node, instead of seeing whether toParam is a node (in the set of nodes).
This fixes the problem described in https://stackoverflow.com/questions/77451478/how-can-i-make-webaudio-param-work-in-elm and probably also my own in trying to create an adsr.
